### PR TITLE
bugfix: not all stap versions support --version, use -V

### DIFF
--- a/stap++
+++ b/stap++
@@ -32,7 +32,7 @@ if ($print_args && $args && %$args) {
     die "No --arg is allowed when --args is specified.\n";
 }
 
-my $ver = `stap --version 2>&1`;
+my $ver = `stap -V 2>&1`;
 if (!defined $ver) {
     die "Systemtap not installed or its \"stap\" utility is not visible to the PATH environment: $!\n";
 }


### PR DESCRIPTION
Replaces stap tool checking to use arg -V instead of --version, not all stap versions support --version, use -V

stap --version fails for stap 1.x releases.

Should we support stap's old versions? will upgrade my version for now :)
