### PR TITLE
LJ_TRACE updates

### DIFF
--- a/samples/ngx-lj-trace-exits.sxx
+++ b/samples/ngx-lj-trace-exits.sxx
@@ -34,7 +34,8 @@ probe @pfunc(ngx_http_free_request)
     }
 }
 
-probe process("$^libluajit_path").function("lj_trace_exit") {
+probe process("$^libluajit_path").function("lj_trace_exit"),
+      process("$^libluajit_path").function("lj_vm_exit_interp") {
     if (active_req) {
         req_exits[active_req]++
     }


### PR DESCRIPTION
Due to the luajit parameter `hotexit` the lj_trace_exit function will
only happens the number of times that hotexit happens.

This will also probe the `lj_vm_exit_interp` function to make sure that
all luajit function is in there.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>